### PR TITLE
Execute Commands on SSH instance (ECC-7436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 
 ### Added
+- Execute commands Plugin
+  - Execute a given command on a given SSH instance
+  - allow for File input or not input
+  - Can create output files or just structured output
+
+### Added
 
 - initial version
 - List Plugin
@@ -15,3 +21,4 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   - Download files from a given SSH instance
 - Upload Plugin
   - Upload files from a given SSH instance
+

--- a/cmem_plugin_ssh/execute_commands.py
+++ b/cmem_plugin_ssh/execute_commands.py
@@ -63,7 +63,7 @@ folder in which the command should be executed in.
 * **No input:** The command will be executed with no input attached to the plugin. Stdin
 is non-existent in this case.
 * **File input:** The command will be executed with the stdin being represented by the
-files that are connected via the input port of the plugin. This also allows for looping 
+files that are connected via the input port of the plugin. This also allows for looping
 over multiple files executing the same command over them.
 
 
@@ -292,10 +292,10 @@ class ExecuteCommands(WorkflowPlugin):
             if self.output_method == FILE_OUTPUT:
                 output_bytes = stdout.read()
                 tmp_dir = tempfile.mkdtemp()
-                tmp_path = Path(tmp_dir) / f"{stdin_file.path}_stdout.bin"
+                input_filename = Path(stdin_file.path).name
+                tmp_path = Path(tmp_dir) / f"{input_filename}_stdout.bin"
                 with Path.open(tmp_path, "wb") as f:
                     f.write(output_bytes)
-
                 local_file = LocalFile(path=str(tmp_path))
                 entity = FileEntitySchema().to_entity(value=local_file)
                 entities.append(entity)

--- a/cmem_plugin_ssh/execute_commands.py
+++ b/cmem_plugin_ssh/execute_commands.py
@@ -36,7 +36,7 @@ from cmem_plugin_ssh.utils import AUTHENTICATION_CHOICES
             label="Authentication method",
             description="The method that is used to connect to the SSH server.",
             param_type=ChoiceParameterType(AUTHENTICATION_CHOICES),
-            default_value=AUTHENTICATION_CHOICES["password"],
+            default_value="password",
         ),
         PluginParameter(
             name="private_key",

--- a/cmem_plugin_ssh/execute_commands.py
+++ b/cmem_plugin_ssh/execute_commands.py
@@ -1,1 +1,64 @@
 """Execute command task workflow plugin"""
+from cmem_plugin_base.dataintegration.description import Icon, PluginParameter
+from cmem_plugin_base.dataintegration.parameter.choice import ChoiceParameterType
+from cmem_plugin_base.dataintegration.parameter.password import PasswordParameterType
+
+from cmem_plugin_ssh.autocompletion import DirectoryParameterType
+from cmem_plugin_ssh.utils import AUTHENTICATION_CHOICES
+
+
+@Plugin(
+    label="Execute commands via SSH",
+    plugin_id="cmem_plugin_ssh-Execute",
+    description="Execute commands on a given SSH instance.",
+    documentation="""
+    """,
+    icon=Icon(package=__package__, file_name="ssh-icon.svg"),
+    parameters=[
+        PluginParameter(
+            name="hostname",
+            label="Hostname",
+            description="Hostname to connect to.Usually in the form of an IP address",
+        ),
+        PluginParameter(
+            name="port",
+            label="Port",
+            description="The port on which the connection will be tried on. Default is 22.",
+            default_value=22,
+        ),
+        PluginParameter(
+            name="username",
+            label="Username",
+            description="The username of which a connection will be instantiated.",
+        ),
+        PluginParameter(
+            name="authentication_method",
+            label="Authentication method",
+            description="The method that is used to connect to the SSH server.",
+            param_type=ChoiceParameterType(AUTHENTICATION_CHOICES),
+            default_value=AUTHENTICATION_CHOICES["password"],
+        ),
+        PluginParameter(
+            name="private_key",
+            label="Private key",
+            description="Your private key to connect via SSH.",
+            param_type=PasswordParameterType(),
+            default_value="",
+        ),
+        PluginParameter(
+            name="password",
+            label="Password",
+            description="Depending on your authentication method this will either be used to"
+            "connect via password to SSH or is used to decrypt the SSH private key",
+            param_type=PasswordParameterType(),
+            default_value="",
+        ),
+        PluginParameter(
+            name="path",
+            label="Path",
+            description="The currently selected path withing your SSH instance.",
+            default_value="",
+            param_type=DirectoryParameterType("directories", "Folder"),
+        ),
+    ],
+)

--- a/cmem_plugin_ssh/execute_commands.py
+++ b/cmem_plugin_ssh/execute_commands.py
@@ -105,7 +105,8 @@ def setup_timeout(timeout: float) -> None | float:
             name="input_method",
             label="Input method",
             description="Parameter to decide weather files will be used as stdin or no input is "
-            "needed.",
+            "needed. If 'File input' is chosen, the input port will open for all entities with"
+            "the FileEntitySchema.",
             param_type=ChoiceParameterType(COMMAND_INPUT_CHOICES),
         ),
         PluginParameter(
@@ -119,7 +120,8 @@ def setup_timeout(timeout: float) -> None | float:
         PluginParameter(
             name="command",
             label="Command",
-            description="The command that will be executed on the SSH instance.",
+            description="The command that will be executed on the SSH instance. When the input"
+            "method is set to 'File input', the command will be executed over these files.",
             default_value="ls",
         ),
         PluginParameter(

--- a/cmem_plugin_ssh/execute_commands.py
+++ b/cmem_plugin_ssh/execute_commands.py
@@ -1,7 +1,8 @@
 """Execute command task workflow plugin"""
-
+import os
 import tempfile
 from collections.abc import Sequence
+from pathlib import Path
 
 import paramiko
 from cmem_plugin_base.dataintegration.context import ExecutionContext, ExecutionReport
@@ -262,11 +263,12 @@ class ExecuteCommands(WorkflowPlugin):
 
             if self.output_method == FILE_OUTPUT:
                 output_bytes = stdout.read()
-                with tempfile.NamedTemporaryFile("wb") as tmp_file:
-                    tmp_file.write(output_bytes)
-                    tmp_path = tmp_file.name
+                tmp_dir = tempfile.mkdtemp()
+                tmp_path = Path(tmp_dir) / "stdout.bin"
+                with Path.open(tmp_path, "wb") as f:
+                    f.write(output_bytes)
 
-                local_file = LocalFile(path=tmp_path)
+                local_file = LocalFile(path=str(tmp_path))
                 entity = FileEntitySchema().to_entity(value=local_file)
                 entities.append(entity)
 
@@ -284,11 +286,12 @@ class ExecuteCommands(WorkflowPlugin):
             entities.append(entity)
         if self.output_method == FILE_OUTPUT:
             output_bytes = stdout.read()
-            with tempfile.NamedTemporaryFile("wb") as tmp_file:
-                tmp_file.write(output_bytes)
-                tmp_path = tmp_file.name
+            tmp_dir = tempfile.mkdtemp()
+            tmp_path = Path(tmp_dir) / "stdout.bin"
+            with Path.open(tmp_path, "wb") as f:
+                f.write(output_bytes)
 
-            local_file = LocalFile(path=tmp_path)
+            local_file = LocalFile(path=str(tmp_path))
             entity = FileEntitySchema().to_entity(value=local_file)
             entities.append(entity)
 

--- a/cmem_plugin_ssh/execute_commands.py
+++ b/cmem_plugin_ssh/execute_commands.py
@@ -1,10 +1,31 @@
 """Execute command task workflow plugin"""
-from cmem_plugin_base.dataintegration.description import Icon, PluginParameter
+
+from collections.abc import Sequence
+
+import paramiko
+from cmem_plugin_base.dataintegration.context import ExecutionContext
+from cmem_plugin_base.dataintegration.description import Icon, Plugin, PluginParameter
+from cmem_plugin_base.dataintegration.entity import Entities, Entity, EntityPath, EntitySchema
 from cmem_plugin_base.dataintegration.parameter.choice import ChoiceParameterType
-from cmem_plugin_base.dataintegration.parameter.password import PasswordParameterType
+from cmem_plugin_base.dataintegration.parameter.password import Password, PasswordParameterType
+from cmem_plugin_base.dataintegration.plugins import WorkflowPlugin
+from cmem_plugin_base.dataintegration.ports import FixedNumberOfInputs, FixedSchemaPort
+from cmem_plugin_base.dataintegration.typed_entities.file import FileEntitySchema
 
 from cmem_plugin_ssh.autocompletion import DirectoryParameterType
-from cmem_plugin_ssh.utils import AUTHENTICATION_CHOICES
+from cmem_plugin_ssh.utils import AUTHENTICATION_CHOICES, load_private_key
+
+
+def generate_schema() -> EntitySchema:
+    """Generate the schema for entities"""
+    return EntitySchema(
+        type_uri="",
+        paths=[
+            EntityPath(path="exit_code"),
+            EntityPath(path="std_out"),
+            EntityPath(path="std_err"),
+        ],
+    )
 
 
 @Plugin(
@@ -18,7 +39,7 @@ from cmem_plugin_ssh.utils import AUTHENTICATION_CHOICES
         PluginParameter(
             name="hostname",
             label="Hostname",
-            description="Hostname to connect to.Usually in the form of an IP address",
+            description="Hostname to connect to. Usually in the form of an IP address",
         ),
         PluginParameter(
             name="port",
@@ -60,5 +81,96 @@ from cmem_plugin_ssh.utils import AUTHENTICATION_CHOICES
             default_value="",
             param_type=DirectoryParameterType("directories", "Folder"),
         ),
+        PluginParameter(
+            name="command",
+            label="Command",
+            description="The command that will be executed on the SSH instance.",
+            default_value="ls",
+        ),
+        PluginParameter(
+            name="timeout",
+            label="Timeout",
+            description="A timeout for the executed command.",
+            default_value=0,
+        ),
     ],
 )
+class ExecuteCommands(WorkflowPlugin):
+    """Execute commands Plugin SSH"""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        hostname: str,
+        port: int,
+        username: str,
+        authentication_method: str,
+        private_key: str | Password,
+        password: str | Password,
+        path: str,
+        command: str,
+        timeout: int,
+    ):
+        self.hostname = hostname
+        self.port = port
+        self.username = username
+        self.authentication_method = authentication_method
+        self.private_key = private_key
+        self.password = password if isinstance(password, str) else password.decrypt()
+        self.path = path
+        self.command = command
+        self.timeout = timeout
+        self.input_ports = FixedNumberOfInputs([FixedSchemaPort(schema=FileEntitySchema())])
+        self.output_port = FixedSchemaPort(schema=generate_schema())
+        self.ssh_client = paramiko.SSHClient()
+        self.connect_ssh_client()
+        self.sftp = self.ssh_client.open_sftp()
+
+    def connect_ssh_client(self) -> None:
+        """Connect to the ssh client with the selected authentication method"""
+        if self.authentication_method == "key":
+            self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            self.ssh_client.connect(
+                hostname=self.hostname,
+                username=self.username,
+                pkey=load_private_key(self.private_key, self.password),
+                password=self.password,
+                port=self.port,
+                timeout=20,
+            )
+        elif self.authentication_method == "password":
+            self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            self.ssh_client.connect(
+                hostname=self.hostname,
+                username=self.username,
+                password=self.password,
+                port=self.port,
+                timeout=20,
+            )
+
+    def close_connections(self) -> None:
+        """Close connection from sftp and ssh"""
+        self.sftp.close()
+        self.ssh_client.close()
+
+    def execute(self, inputs: Sequence[Entities], context: ExecutionContext) -> Entities | None:
+        """Execute the workflow task"""
+        input_data = None
+
+        files = inputs[0].entities
+        for file in files:
+            stdin_file = FileEntitySchema().from_entity(file)
+            with stdin_file.read_stream(context.task.project_id()) as stdin:
+                input_data = stdin.read()
+
+        stdin, stdout, stderr = self.ssh_client.exec_command(self.command)
+        stdin.write(input_data)
+        stdin.channel.shutdown_write()
+
+        output = stdout.read().decode("utf-8")
+        error = stderr.read().decode("utf-8")
+        exit_code = stdout.channel.recv_exit_status()
+        self.close_connections()
+
+        entity = Entity(uri=f"{self.hostname}", values=[[str(exit_code)], [output], [error]])
+
+        return Entities(entities=iter([entity]), schema=generate_schema())

--- a/cmem_plugin_ssh/execute_commands.py
+++ b/cmem_plugin_ssh/execute_commands.py
@@ -54,6 +54,34 @@ def setup_timeout(timeout: float) -> None | float:
     plugin_id="cmem_plugin_ssh-Execute",
     description="Execute commands on a given SSH instance.",
     documentation="""
+This workflow task executes commands on a given SSH instance.
+
+By providing the hostname, username, port and authentication method, you can specify the
+folder in which the command should be executed in.
+
+#### Input Methods:
+* **No input:** The command will be executed with no input attached to the plugin. Stdin
+is non-existent in this case.
+* **File input:** The command will be executed with the stdin being represented by the
+files that are connected via the input port of the plugin. This also allows for looping 
+over multiple files executing the same command over them.
+
+
+#### Output Methods:
+* **Structured process output:** The output will produce entities with its own schema including
+the stdout and stderr as well as the exit code to confirm the execution of the command.
+* **File output:** The stdout will be converted into a file a be provided for further use.
+* **No output:** The output port will be closed.
+
+#### Authentication Methods:
+* **Password:** Only the password will be used for authentication. The private key field is
+ignored, even if filled.
+* **Key:** The private key will be used for authentication. If the key is encrypted, the password
+will be used to decrypt it.
+
+#### Note:
+* If a connection cannot be established within 20 seconds, a timeout occurs.
+* Currently supported key types are: RSA, DSS, ECDSA, Ed25519.
     """,
     icon=Icon(package=__package__, file_name="ssh-icon.svg"),
     parameters=[

--- a/cmem_plugin_ssh/execute_commands.py
+++ b/cmem_plugin_ssh/execute_commands.py
@@ -211,20 +211,24 @@ class ExecuteCommands(WorkflowPlugin):
 
         self.close_connections()
 
+        operation_desc = (
+            f"times executed '{self.command}'"
+            if len(entities) > 1
+            else f"executed '{self.command}'"
+        )
+
+        schema = generate_schema() if self.output_method == STRUCTURED_OUPUT else FileEntitySchema()
+
         context.report.update(
             ExecutionReport(
                 entity_count=len(entities),
                 operation="done",
-                operation_desc=f"executed '{self.command}'",
+                operation_desc=operation_desc,
+                sample_entities=Entities(entities=iter(entities[:10]), schema=schema),
             )
         )
 
-        return Entities(
-            entities=iter(entities),
-            schema=generate_schema()
-            if self.output_method == STRUCTURED_OUPUT
-            else FileEntitySchema(),
-        )
+        return Entities(entities=iter(entities), schema=schema)
 
     def input_execution(
         self, context: ExecutionContext, entities: list, inputs: Sequence[Entities]

--- a/cmem_plugin_ssh/execute_commands.py
+++ b/cmem_plugin_ssh/execute_commands.py
@@ -193,9 +193,9 @@ class ExecuteCommands(WorkflowPlugin):
         self.sftp.close()
         self.ssh_client.close()
 
-    def execute(self, inputs: Sequence[Entities], context: ExecutionContext) -> Entities | None:
+    def execute(self, inputs: Sequence[Entities], context: ExecutionContext) -> Entities:
         """Execute the workflow task"""
-        entities = []
+        entities: list = []
         if self.input_method == "file_input":
             self.input_execution(context, entities, inputs)
 
@@ -211,7 +211,7 @@ class ExecuteCommands(WorkflowPlugin):
         )
 
     def input_execution(
-        self, context: ExecutionContext(), entities: list, inputs: Sequence[Entities]
+        self, context: ExecutionContext, entities: list, inputs: Sequence[Entities]
     ) -> None:
         """Execute the command with given input files"""
         files = inputs[0].entities

--- a/cmem_plugin_ssh/execute_commands.py
+++ b/cmem_plugin_ssh/execute_commands.py
@@ -1,5 +1,5 @@
 """Execute command task workflow plugin"""
-import os
+
 import tempfile
 from collections.abc import Sequence
 from pathlib import Path
@@ -264,7 +264,7 @@ class ExecuteCommands(WorkflowPlugin):
             if self.output_method == FILE_OUTPUT:
                 output_bytes = stdout.read()
                 tmp_dir = tempfile.mkdtemp()
-                tmp_path = Path(tmp_dir) / "stdout.bin"
+                tmp_path = Path(tmp_dir) / f"{stdin_file.path}_stdout.bin"
                 with Path.open(tmp_path, "wb") as f:
                     f.write(output_bytes)
 

--- a/cmem_plugin_ssh/execute_commands.py
+++ b/cmem_plugin_ssh/execute_commands.py
@@ -1,0 +1,1 @@
+"""Execute command task workflow plugin"""

--- a/cmem_plugin_ssh/upload.py
+++ b/cmem_plugin_ssh/upload.py
@@ -61,7 +61,7 @@ will be used to decrypt it.
             label="Authentication method",
             description="The method that is used to connect to the SSH server.",
             param_type=ChoiceParameterType(AUTHENTICATION_CHOICES),
-            default_value=AUTHENTICATION_CHOICES["password"],
+            default_value="password",
         ),
         PluginParameter(
             name="private_key",

--- a/cmem_plugin_ssh/upload.py
+++ b/cmem_plugin_ssh/upload.py
@@ -43,7 +43,7 @@ will be used to decrypt it.
         PluginParameter(
             name="hostname",
             label="Hostname",
-            description="Hostname to connect to.Usually in the form of an IP address",
+            description="Hostname to connect to. Usually in the form of an IP address",
         ),
         PluginParameter(
             name="port",

--- a/cmem_plugin_ssh/utils.py
+++ b/cmem_plugin_ssh/utils.py
@@ -19,6 +19,21 @@ WARNING = "warning"
 ERROR = "error"
 ERROR_HANDLING_CHOICES = OrderedDict({IGNORE: "Ignore", WARNING: "Warning", ERROR: "Error"})
 
+NO_INPUT = "no_input"
+FILE_INPUT = "file_input"
+COMMAND_INPUT_CHOICES = OrderedDict({NO_INPUT: "No input", FILE_INPUT: "File input"})
+
+NO_OUTPUT = "no_output"
+STRUCTURED_OUPUT = "structured_output"
+FILE_OUTPUT = "file_output"
+COMMAND_OUTPUT_CHOICES = OrderedDict(
+    {
+        NO_OUTPUT: "No output",
+        STRUCTURED_OUPUT: "Structured process output",
+        FILE_OUTPUT: "File output",
+    }
+)
+
 MAX_WORKERS = 32
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from cmem_plugin_ssh.download import DownloadFiles
+from cmem_plugin_ssh.execute_commands import ExecuteCommands
 from cmem_plugin_ssh.list import ListFiles
 from cmem_plugin_ssh.upload import UploadFiles
 from tests.fixtures import (
@@ -37,10 +38,15 @@ class TestingEnvironment:
     path: str
     regex: str
     no_subfolder: bool
+    input_method: str
+    output_method: str
+    command: str
+    timeout: float
     restricted_file: str
     list_plugin: ListFiles
     download_plugin: DownloadFiles
     upload_plugin: UploadFiles
+    execute_plugin: ExecuteCommands
     no_of_files: int = 12
 
 
@@ -57,6 +63,10 @@ def testing_environment() -> TestingEnvironment:
     error_handling = "error"
     path = "volume"
     regex = "^.*$"
+    input_method = "no_input"
+    output_method = "structured_output"
+    command = "ls -al"
+    timeout = 0
     restricted_file = "/etc/restricted.txt"
     no_subfolder = False
     list_plugin = ListFiles(
@@ -92,6 +102,19 @@ def testing_environment() -> TestingEnvironment:
         password=password,
         authentication_method=authentication_method,
     )
+    execute_plugin = ExecuteCommands(
+        hostname=hostname,
+        port=port,
+        username=username,
+        private_key=private_key,
+        path=path,
+        password=password,
+        authentication_method=authentication_method,
+        input_method=input_method,
+        output_method=output_method,
+        timeout=timeout,
+        command=command,
+    )
 
     return TestingEnvironment(
         hostname=hostname,
@@ -104,11 +127,16 @@ def testing_environment() -> TestingEnvironment:
         path=path,
         no_subfolder=no_subfolder,
         regex=regex,
+        input_method=input_method,
+        output_method=output_method,
+        timeout=timeout,
+        command=command,
         error_handling=error_handling,
         restricted_file=restricted_file,
         list_plugin=list_plugin,
         download_plugin=download_plugin,
         upload_plugin=upload_plugin,
+        execute_plugin=execute_plugin,
     )
 
 

--- a/tests/test_execute_commands.py
+++ b/tests/test_execute_commands.py
@@ -1,1 +1,21 @@
 """Command execution workflow test suite"""
+
+from cmem_plugin_base.testing import TestExecutionContext
+
+from tests.conftest import TestingEnvironment
+
+
+def test_ls_command(testing_environment: TestingEnvironment) -> None:
+    """Test most basic execution of 'ls -al' command with no input"""
+    execute_plugin = testing_environment.execute_plugin
+    results = execute_plugin.execute(inputs=[], context=TestExecutionContext())
+    assert len(list(results.entities)) == 1
+
+
+def test_ls_command_file_output(testing_environment: TestingEnvironment) -> None:
+    """Test most basic execution of 'ls -al' command with no input"""
+    execute_plugin = testing_environment.execute_plugin
+    execute_plugin.output_method = "file_output"
+    results = execute_plugin.execute(inputs=[], context=TestExecutionContext())
+    assert len(list(results.entities)) == 1
+    # need to also test that schema is right here

--- a/tests/test_execute_commands.py
+++ b/tests/test_execute_commands.py
@@ -1,21 +1,42 @@
 """Command execution workflow test suite"""
 
+from pathlib import Path
+
+from cmem_plugin_base.dataintegration.entity import Entities
+from cmem_plugin_base.dataintegration.typed_entities.file import FileEntitySchema, LocalFile
 from cmem_plugin_base.testing import TestExecutionContext
 
 from tests.conftest import TestingEnvironment
 
 
-def test_ls_command(testing_environment: TestingEnvironment) -> None:
+def test_basic_command_execution(testing_environment: TestingEnvironment) -> None:
     """Test most basic execution of 'ls -al' command with no input"""
     execute_plugin = testing_environment.execute_plugin
     results = execute_plugin.execute(inputs=[], context=TestExecutionContext())
     assert len(list(results.entities)) == 1
 
 
-def test_ls_command_file_output(testing_environment: TestingEnvironment) -> None:
+def test_basic_command_execution_file_output(testing_environment: TestingEnvironment) -> None:
     """Test most basic execution of 'ls -al' command with no input"""
     execute_plugin = testing_environment.execute_plugin
     execute_plugin.output_method = "file_output"
     results = execute_plugin.execute(inputs=[], context=TestExecutionContext())
     assert len(list(results.entities)) == 1
     # need to also test that schema is right here
+
+
+def test_basic_command_execution_input_files(testing_environment: TestingEnvironment) -> None:
+    """Test execution with input files"""
+    execute_plugin = testing_environment.execute_plugin
+    execute_plugin.input_method = "file_input"
+    execute_plugin.command = "cat"
+
+    schema = FileEntitySchema()
+    test_file_path = Path(__file__).parent.parent / "docker" / "volume" / "RootFile.txt"
+    files = [LocalFile(path=str(test_file_path.resolve()), mime="")]
+    entities = [schema.to_entity(file) for file in files]
+    input_entities = Entities(entities=iter(entities), schema=schema)
+
+    execute_result = execute_plugin.execute(inputs=[input_entities], context=TestExecutionContext())
+    execute_result_exit_code = [e.values[0][0] for e in execute_result.entities]
+    assert "0" in execute_result_exit_code

--- a/tests/test_execute_commands.py
+++ b/tests/test_execute_commands.py
@@ -1,0 +1,1 @@
+"""Command execution workflow test suite"""

--- a/tests/test_execute_commands.py
+++ b/tests/test_execute_commands.py
@@ -40,3 +40,23 @@ def test_basic_command_execution_input_files(testing_environment: TestingEnviron
     execute_result = execute_plugin.execute(inputs=[input_entities], context=TestExecutionContext())
     execute_result_exit_code = [e.values[0][0] for e in execute_result.entities]
     assert "0" in execute_result_exit_code
+
+
+def test_basic_command_execution_input_files_file_output(
+    testing_environment: TestingEnvironment,
+) -> None:
+    """Test execution with input files"""
+    execute_plugin = testing_environment.execute_plugin
+    execute_plugin.input_method = "file_input"
+    execute_plugin.command = "cat"
+    execute_plugin.output_method = "file_output"
+
+    schema = FileEntitySchema()
+    test_file_path = Path(__file__).parent.parent / "docker" / "volume" / "RootFile.txt"
+    files = [LocalFile(path=str(test_file_path.resolve()), mime="")]
+    entities = [schema.to_entity(file) for file in files]
+    input_entities = Entities(entities=iter(entities), schema=schema)
+
+    execute_result = execute_plugin.execute(inputs=[input_entities], context=TestExecutionContext())
+    execute_result_file_type = [e.values[1][0] for e in execute_result.entities]
+    assert "Local" in execute_result_file_type


### PR DESCRIPTION
## Execute Commands Plugin
- Allow execution of commands on a given SSH instance

### Input
- Allow input to be of files or no files
- If files is selected, the command gets executed over these files as they are seen as the stdin

### Output
- Allow output to be files, structured output with own schema or not output
- if output is files, for each execution a file with the result will be created and be provided
- if output is strucutured output, a strucutured output with the exit code, stdout, stderr will be created
- if no output is selected, the output port gets closed

